### PR TITLE
📖 [Docs]: README pages now use the standard module landing-page format

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ Import-Module -Name PSCredential
 
 Documentation is published at [psmodule.io/PSCredential](https://psmodule.io/PSCredential/).
 
+Saved credentials use PowerShell's `Export-Clixml` protection model. Review the command help before using saved credentials outside your own user profile and machine context.
+
 Use PowerShell help and command discovery for module details:
 
 ```powershell
 Get-Command -Module PSCredential
-Get-Help <CommandName> -Examples
+Get-Help Save-PSCredential -Examples
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,108 +1,27 @@
 # PSCredential
 
-`PSCredential` is a PowerShell module that provides functions for managing credentials.
-It allows users to create, save, and restore `PSCredential` objects from disk.
-
-## Prerequisites
-
-This module requires:
-
-- The [PSModule framework](https://github.com/PSModule) for building, testing, and publishing the module.
+PSCredential is a PowerShell module for managing PSCredential objects.
 
 ## Installation
 
-To install the module from the PowerShell Gallery, you can use the following command:
+Install the module from the PowerShell Gallery:
 
 ```powershell
 Install-PSResource -Name PSCredential
 Import-Module -Name PSCredential
 ```
 
-## Usage
-
-Here are some typical use cases for the module.
-
-### Example 1: Creating a new `PSCredential` object
-
-This function generates a `PSCredential` object using user input.
-
-```powershell
-New-PSCredential
-```
-
-This prompts the user for a username and password and returns a `PSCredential` object.
-
-Alternatively, you can specify the credentials explicitly:
-
-```powershell
-New-PSCredential -Username 'admin' -Password (ConvertTo-SecureString 'P@ssw0rd!' -AsPlainText -Force)
-```
-
-### Example 2: Saving a `PSCredential` object to a file
-
-You can save a credential to a file using `Save-PSCredential`:
-
-```powershell
-$credential = Get-Credential
-Save-PSCredential -Credential $credential -Path 'C:\secure\credential.cred'
-```
-
-This saves the credential to `C:\secure\credential.cred`.
-
-### Example 3: Restoring a `PSCredential` object from a file
-
-To restore a credential object from a previously saved file:
-
-```powershell
-Restore-PSCredential -Path 'C:\secure\credential.cred'
-```
-
-Alternatively, you can use pipeline input:
-
-```powershell
-'C:\secure\credential.cred' | Restore-PSCredential
-```
-
-### Find more examples
-
-To find more examples of how to use the module, please refer to the [examples](examples) folder.
-
-Alternatively, you can use the following commands:
-
-- Find available commands in the module:
-
-  ```powershell
-  Get-Command -Module PSCredential
-  ```
-
-- Get examples for a specific command:
-
-  ```powershell
-  Get-Help -Examples New-PSCredential
-  ```
-
 ## Documentation
 
-For further documentation, please refer to:
+Documentation is published at [psmodule.io/PSCredential](https://psmodule.io/PSCredential/).
 
-- [PSCredential](https://psmodule.io/PSCredential/)
+Use PowerShell help and command discovery for module details:
+
+```powershell
+Get-Command -Module PSCredential
+Get-Help <CommandName> -Examples
+```
 
 ## Contributing
 
-Whether you're a coder or not, you can contribute to this project!
-
-### For Users
-
-If you experience unexpected behavior, errors, or missing functionality, you can help by submitting bug reports and feature requests.
-Please visit the [issues tab](https://github.com/PSModule/PSCredential/issues) and submit a new issue.
-
-### For Developers
-
-If you are a developer, we welcome your contributions!
-Please read the [Contribution Guidelines](CONTRIBUTING.md) for more information.
-You can either help by picking up an existing issue or submit a new one if you have an idea for a feature or improvement.
-
-## Disclaimer
-
-The Export-Clixml cmdlet is used to save credentials to disk, is not secure on Linux and macOS, and should be used with caution.
-For more information read the [Export-Clixml](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/export-clixml?view=powershell-7.5#example-4-exporting-a-credential-object-on-linux-or-macos) documentation.
+Issues and pull requests are welcome. Please use the repository issue tracker to report bugs, request features, or discuss improvements.


### PR DESCRIPTION
README pages now act as concise landing pages. Implemented modules point users to installation, psmodule.io, and PowerShell help instead of duplicating command reference content. Placeholder and in-progress modules now state their status clearly so users are not shown scaffold examples as working usage.

> ⚠️ This PR has no linked issue. Consider creating one for traceability.

## Changed: README pages defer to generated documentation

Implemented module READMEs now provide a short overview, installation commands, and links to generated documentation. Command usage remains in PowerShell help and generated docs.

```powershell
Get-Command -Module <ModuleName>
Get-Help -Name 'CommandName' -Examples
```

## Changed: Placeholder modules identify their status

Repositories that still contain scaffold or stub module code now say they are placeholders or in progress instead of showing template commands as if they worked.

## Technical Details

- Updates `README.md` only.
- Aligns repository READMEs with the default introduced in `PSModule/Template-PSModule`.
- Keeps command-level details out of README pages to avoid duplicating generated module documentation.
